### PR TITLE
Added a 100fps wait before we can decrement the music timer

### DIFF
--- a/Game/ObjectDLL/ObjectShared/GameServerShell.h
+++ b/Game/ObjectDLL/ObjectShared/GameServerShell.h
@@ -201,6 +201,11 @@ class CGameServerShell : public IServerShellStub
 
         void        SendPlayerInfoMsgToClients(HCLIENT hClients, CPlayerObj *pPlayer, uint8 nInfoType);
 
+		//
+		// Lithtech servers seem to be capped at 100fps.
+		//
+		LTFLOAT GetMaxServerFrametime() { return (1.0f / 100.0f); }
+
 	protected :
 
 	    virtual LTRESULT	OnServerInitialized();
@@ -348,6 +353,7 @@ class CGameServerShell : public IServerShellStub
 		// Gets the clientdata given a HCLIENT.
 		ClientData* GetClientData( HCLIENT hClient );
 
+
 	protected:
 
 		TimeRamp			m_TimeRamps[MAX_TIME_RAMPS];
@@ -463,6 +469,7 @@ class CGameServerShell : public IServerShellStub
 
 		typedef std::vector< ClientData* > ClientDataList;
 		ClientDataList	m_ClientDataList;
+
 };
 
 extern class CGameServerShell* g_pGameServerShell;

--- a/Game/ObjectDLL/ObjectShared/MusicMgr.cpp
+++ b/Game/ObjectDLL/ObjectShared/MusicMgr.cpp
@@ -257,7 +257,10 @@ void CMusicMgr::Update()
 
 	// Check that function for details
 	// But basically, we gotta wait until the time is riiiiight.
-	if (!IsItTimeToRun()) return;
+	if (!IsItTimeToRun())
+	{
+		return;
+	}
 
 	LTBOOL bChoseMood = LTFALSE;
 

--- a/Game/ObjectDLL/ObjectShared/MusicMgr.cpp
+++ b/Game/ObjectDLL/ObjectShared/MusicMgr.cpp
@@ -5,6 +5,7 @@
 #include "GameButeMgr.h"
 #include "MsgIds.h"
 #include "GameServerShell.h"
+#include <SDL.h>
 
 extern CGameServerShell* g_pGameServerShell;
 
@@ -62,6 +63,8 @@ CMusicMgr::CMusicMgr()
 	m_pMusicButeMgr = NULL;
 
 	m_bInitialized = LTFALSE;
+
+	m_fLastTime = 0;
 }
 
 // ----------------------------------------------------------------------- //
@@ -213,7 +216,16 @@ void CMusicMgr::Load(ILTMessage_Read *pMsg)
 
 void CMusicMgr::Update()
 {
-	if ( !m_bEnabled ) return;
+	// Don't update music intensity if we're paused!
+	if (g_pGameServerShell->IsPaused())
+	{
+		return;
+	}
+
+	if (!m_bEnabled) 
+	{
+		return;
+	}
 
 	if ( m_bLockedMood )
 	{
@@ -242,6 +254,10 @@ void CMusicMgr::Update()
 
 		return;
 	}
+
+	// Check that function for details
+	// But basically, we gotta wait until the time is riiiiight.
+	if (!IsItTimeToRun()) return;
 
 	LTBOOL bChoseMood = LTFALSE;
 
@@ -299,6 +315,23 @@ void CMusicMgr::DoEvent(Event eEvent)
 		g_pLTServer->SendToClient(cMsg.Read(), LTNULL, MESSAGE_GUARANTEED);
 		FREE_HSTRING(hMusic);
 	}
+}
+
+bool CMusicMgr::IsItTimeToRun()
+{
+	float fCurrentTime = SDL_GetTicks() / 1000.0f;
+	float fDelta = fCurrentTime - m_fLastTime;
+
+	// Server framerate is capped at 100fps, so uhh..
+	// make sure we don't decrement the music timer until we've gone a full cycle.
+	if (fDelta > g_pGameServerShell->GetMaxServerFrametime())
+	{
+		m_fLastTime = fCurrentTime;
+		return true;
+	}
+
+	return false;
+
 }
 
 // ----------------------------------------------------------------------- //

--- a/Game/ObjectDLL/ObjectShared/MusicMgr.h
+++ b/Game/ObjectDLL/ObjectShared/MusicMgr.h
@@ -84,6 +84,8 @@ class CMusicMgr
 
 		void Enable() { m_bEnabled = LTTRUE; }
 		void Disable() { m_bEnabled = LTFALSE; }
+
+		bool IsItTimeToRun();
 		
 	protected :
 
@@ -112,6 +114,9 @@ class CMusicMgr
 		LTFLOAT		m_afEventChances[kNumEvents];
 
 		LTBOOL		m_bEnabled;
+
+		// For keeping music decrementing in sync
+		LTFLOAT		m_fLastTime;
 };
 
 #endif // MUSICMGR_H


### PR DESCRIPTION
Fixes #2 

Seems to fix the issue, but I'm sure there's a better solution out there. I think this introduced a small delay on music ending, but tested it out in a firefight on locked 60 and unlocked 140~400 and they both transitioned correctly.

Testing included 1 npc being "alerted", and a multi npc combat scenario. 
