### PR TITLE
Add TakeDamage HUD element. It currently always renders the effect.

### DIFF
--- a/Game/ClientShellDLL/ClientShellShared/ClientShellShared.vcxproj
+++ b/Game/ClientShellDLL/ClientShellShared/ClientShellShared.vcxproj
@@ -836,6 +836,7 @@
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'"> /Zm1000   /Zm1000 </AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Final|Win32'"> /Zm1000   /Zm1000 </AdditionalOptions>
     </ClCompile>
+    <ClCompile Include="HUDTakeDamage.cpp" />
     <ClCompile Include="HUDTransmission.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'"> /Zm1000   /Zm1000 </AdditionalOptions>
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'"> /Zm1000   /Zm1000 </AdditionalOptions>
@@ -1425,6 +1426,7 @@
     <ClInclude Include="HUDRadar.h" />
     <ClInclude Include="HUDScores.h" />
     <ClInclude Include="HUDSubtitles.h" />
+    <ClInclude Include="HUDTakeDamage.h" />
     <ClInclude Include="HUDTransmission.h" />
     <ClInclude Include="IntelItemList.h" />
     <ClInclude Include="InterfaceMgr.h" />

--- a/Game/ClientShellDLL/ClientShellShared/ClientShellShared.vcxproj.filters
+++ b/Game/ClientShellDLL/ClientShellShared/ClientShellShared.vcxproj.filters
@@ -674,6 +674,9 @@
     <ClCompile Include="GameInputMgr.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="HUDTakeDamage.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ActivateObjectFX.h">
@@ -1310,6 +1313,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="GameInputMgr.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="HUDTakeDamage.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Game/ClientShellDLL/ClientShellShared/HUDMgr.cpp
+++ b/Game/ClientShellDLL/ClientShellShared/HUDMgr.cpp
@@ -29,6 +29,7 @@ CHUDRewardMsgQueue*	g_pRewardMsgs = LTNULL;
 CHUDPaused*			g_pPaused = LTNULL;
 CHUDDisplayMeter*	g_pDisplayMeter = LTNULL;
 CHUDScores*			g_pScores = LTNULL;
+CHUDTakeDamage*		g_pTakeDamage = nullptr;
 
 // ----------------------------------------------------------------------- //
 //

--- a/Game/ClientShellDLL/ClientShellShared/HUDMgr.h
+++ b/Game/ClientShellDLL/ClientShellShared/HUDMgr.h
@@ -27,6 +27,7 @@
 #include "HUDDisplayMeter.h"
 #include "HUDScores.h"
 #include "HUDConsoleLines.h"
+#include "HUDTakeDamage.h"
 
 enum eHUDUpdateFlag
 {
@@ -55,6 +56,7 @@ enum eHUDUpdateFlag
 	kHUDDoomsday	= 0x00200000,
 	kHUDFramerate   = 0x00400000,
 	kHUDConsoleLines= 0x00800000,
+	kHUDTakeDamage  = 0x01000000,
 	kHUDAll			= 0xFFFFFFFF,
 };
 

--- a/Game/ClientShellDLL/ClientShellShared/HUDMgr.h
+++ b/Game/ClientShellDLL/ClientShellShared/HUDMgr.h
@@ -117,6 +117,9 @@ protected:
 	CHUDScores			m_Scores;
 	CHUDConsoleLines	m_ConsoleLines;
 
+	// This is technically in TO2HudMgr, but it's in Shared namespace..
+	CHUDTakeDamage		m_TakeDamage;
+
 	//items
 	typedef std::vector<CHUDItem *> ItemArray;
 	ItemArray m_itemArray;			// Pointer to each screen
@@ -137,5 +140,6 @@ extern CHUDRewardMsgQueue*	g_pRewardMsgs;
 extern CHUDPaused*			g_pPaused;
 extern CHUDDisplayMeter*	g_pDisplayMeter;
 extern CHUDScores*			g_pScores;
+extern CHUDTakeDamage*		g_pTakeDamage;
 
 #endif

--- a/Game/ClientShellDLL/ClientShellShared/HUDTakeDamage.cpp
+++ b/Game/ClientShellDLL/ClientShellShared/HUDTakeDamage.cpp
@@ -1,35 +1,98 @@
 #include "stdafx.h"
 #include "HUDMgr.h"
 
+// Max items for our vector,
+// also affects how many hits vs the strength of the effect
+#define MAX_LEVELS_OF_PAIN 5
+
+// How long until a single effect fades out
+#define PAIN_TIMEOUT 1000
+
 CHUDTakeDamage::CHUDTakeDamage()
 {
+	m_UpdateFlags = kHUDAll;
+	m_eLevel = kHUDRenderNone;
+	m_hDamageTex = nullptr;
 }
 
 CHUDTakeDamage::~CHUDTakeDamage()
 {
+	m_vLevelsOfPain.clear();
 }
-HTEXTURE g_hDamageTex;
+
 LTBOOL CHUDTakeDamage::Init()
 {
-	g_pDrawPrim->SetRGBA(&m_Poly, SET_ARGB(255, 255, 0, 0));
+	// Give us a niiiiice red.
+	g_pDrawPrim->SetRGBA(&m_Poly, SET_ARGB(0, 255, 0, 0));
 
-	g_hDamageTex = g_pInterfaceResMgr->GetTexture("Interface\\Hud\\SprTex\\ARMORHIT.DTX");
-
-	SetupQuadUVs(m_Poly, g_hDamageTex, 0.0f, 0.0f, 1.0f, 1.0f);
-	g_pDrawPrim->SetXYWH(&m_Poly, 0, 0, g_pInterfaceResMgr->GetScreenWidth(), g_pInterfaceResMgr->GetScreenHeight());
+	// ArmourHit.dtx has a odd placement, so we'll need to adjust the uv's accordingly.
+	m_hDamageTex = g_pInterfaceResMgr->GetTexture("Interface\\Hud\\SprTex\\ARMORHIT.DTX");
+	SetupQuadUVs(m_Poly, m_hDamageTex, 0.0f, 0.125f, 1.0f, 0.725f);
 
     return LTTRUE;
 }
 
 void CHUDTakeDamage::Render()
 {
+	if (m_vLevelsOfPain.size() == 0)
+	{
+		return;
+	}
+
 	SetRenderState();
 
-	g_pDrawPrim->SetTexture(g_hDamageTex);
+	g_pDrawPrim->SetXYWH(&m_Poly, 0, 0, g_pInterfaceResMgr->GetScreenWidth(), g_pInterfaceResMgr->GetScreenHeight());
+	g_pDrawPrim->SetTexture(m_hDamageTex);
 	g_pDrawPrim->DrawPrim(&m_Poly);
 }
 
 void CHUDTakeDamage::Update()
 {
+	int nAlpha = 0;
 
+	// Create a local copy to iterate over
+	auto vLocalPain(m_vLevelsOfPain);
+
+	for (int i = 0; i < vLocalPain.size(); i++)
+	{
+		// Amount we're adding to our total alpha this frame
+		int nAdd = 255 / MAX_LEVELS_OF_PAIN;
+
+		auto nCurrentTime = SDL_GetTicks();
+		auto nTotalTime = nCurrentTime - vLocalPain[i];
+		vLocalPain[i] = nTotalTime;
+
+		// Check if times up!
+		if (nTotalTime > PAIN_TIMEOUT)
+		{
+			// Ok, remove this level of pain from the og version
+			// Since the timers are linearly added, we can just remove the first entry.
+			m_vLevelsOfPain.erase(m_vLevelsOfPain.begin());
+			continue;
+		}
+
+		if (nTotalTime != 0)
+		{
+			// If we've got time then let's inversely scale the add.
+			// Lower values will give us high amount of nAdd, and it'll fade out over time.
+			nAdd *= (float)(1.0f - ((float)nTotalTime / (float)PAIN_TIMEOUT));
+		}
+
+		nAlpha += nAdd; 
+	}
+
+	g_pDrawPrim->SetRGBA(&m_Poly, SET_ARGB(nAlpha, 255, 0, 0));
+}
+
+//
+// On call, add the current time in ticks to our timer vector
+//
+void CHUDTakeDamage::TakeDamage()
+{
+	if (m_vLevelsOfPain.size() >= 5)
+	{
+		return;
+	}
+
+	m_vLevelsOfPain.push_back(SDL_GetTicks());
 }

--- a/Game/ClientShellDLL/ClientShellShared/HUDTakeDamage.cpp
+++ b/Game/ClientShellDLL/ClientShellShared/HUDTakeDamage.cpp
@@ -1,0 +1,35 @@
+#include "stdafx.h"
+#include "HUDMgr.h"
+
+CHUDTakeDamage::CHUDTakeDamage()
+{
+}
+
+CHUDTakeDamage::~CHUDTakeDamage()
+{
+}
+HTEXTURE g_hDamageTex;
+LTBOOL CHUDTakeDamage::Init()
+{
+	g_pDrawPrim->SetRGBA(&m_Poly, SET_ARGB(255, 255, 0, 0));
+
+	g_hDamageTex = g_pInterfaceResMgr->GetTexture("Interface\\Hud\\SprTex\\ARMORHIT.DTX");
+
+	SetupQuadUVs(m_Poly, g_hDamageTex, 0.0f, 0.0f, 1.0f, 1.0f);
+	g_pDrawPrim->SetXYWH(&m_Poly, 0, 0, g_pInterfaceResMgr->GetScreenWidth(), g_pInterfaceResMgr->GetScreenHeight());
+
+    return LTTRUE;
+}
+
+void CHUDTakeDamage::Render()
+{
+	SetRenderState();
+
+	g_pDrawPrim->SetTexture(g_hDamageTex);
+	g_pDrawPrim->DrawPrim(&m_Poly);
+}
+
+void CHUDTakeDamage::Update()
+{
+
+}

--- a/Game/ClientShellDLL/ClientShellShared/HUDTakeDamage.h
+++ b/Game/ClientShellDLL/ClientShellShared/HUDTakeDamage.h
@@ -1,28 +1,32 @@
 #pragma once
+#include <vector>
+#include <SDL.h>
 #include "HUDItem.h"
-class CHUDTakeDamage :
-    public CHUDItem
+
+// HUD Take Damage
+// Replacement for TakingHealth FX
+// -------------------------------
+// I couldn't figure out how spriteFX were drawn, 
+// so I disabled the current one in PlayerMgr 
+// and re-created it as a HUD item.
+//
+class CHUDTakeDamage : public CHUDItem
 {
 public:
 	CHUDTakeDamage();
 	~CHUDTakeDamage();
 
-	LTBOOL      Init();
+	LTBOOL  Init();
 
-	void        Render();
-	void        Update();
+	void    Render();
+	void    Update();
 
-	//void        UpdateLayout();
+	void	TakeDamage();
 
 private:
-	LTIntPt		m_BasePos;
-	uint16 		m_nIconHt;
-
-	LTBOOL		m_bDraw;
-
-
 	LTPoly_GT4 m_Poly;
-	HTEXTURE* m_hIcon;			//  icon
+	HTEXTURE m_hDamageTex;
 
+	std::vector<Uint32> m_vLevelsOfPain;
 };
 

--- a/Game/ClientShellDLL/ClientShellShared/HUDTakeDamage.h
+++ b/Game/ClientShellDLL/ClientShellShared/HUDTakeDamage.h
@@ -1,0 +1,28 @@
+#pragma once
+#include "HUDItem.h"
+class CHUDTakeDamage :
+    public CHUDItem
+{
+public:
+	CHUDTakeDamage();
+	~CHUDTakeDamage();
+
+	LTBOOL      Init();
+
+	void        Render();
+	void        Update();
+
+	//void        UpdateLayout();
+
+private:
+	LTIntPt		m_BasePos;
+	uint16 		m_nIconHt;
+
+	LTBOOL		m_bDraw;
+
+
+	LTPoly_GT4 m_Poly;
+	HTEXTURE* m_hIcon;			//  icon
+
+};
+

--- a/Game/ClientShellDLL/ClientShellShared/PlayerMgr.cpp
+++ b/Game/ClientShellDLL/ClientShellShared/PlayerMgr.cpp
@@ -44,6 +44,7 @@
 #include "LTEulerAngles.h"
 #include "DoomsDayPieceFX.h"
 #include <SDL.h>
+#include "HUDMgr.h"
 
 extern SDL_Window* g_SDLWindow;
 
@@ -1388,6 +1389,17 @@ void CPlayerMgr::HandleMsgPlayerDamage (ILTMessage_Read *pMsg)
 
 	DamageFlags dmgFlag = DamageTypeToFlag( eType );
 
+	// New "Red Hurty" effect.
+	if (bTookHealth)
+	{
+		g_pTakeDamage->TakeDamage();
+	}
+
+	// Jake: For whoever wants to fix it on the FX-side,
+	// below is the original "Red Hurty" effect, I couldn't figure out how to alter its scale
+	// so I replaced it with the HUD item above.
+	// Note: TakingArmorFXName is actually never used anywhere...
+#if 0
 	if( bTookHealth )
 	{
 		// Play the taking health fx for the DamageFX associated with the damage type...
@@ -1424,6 +1436,7 @@ void CPlayerMgr::HandleMsgPlayerDamage (ILTMessage_Read *pMsg)
 			pDamageFX = g_pDamageFXMgr->GetNextDamageFX();
 		}
 	}
+#endif
 
 	// Tilt the camera based on the direction the damage came from...
 

--- a/Game/ClientShellDLL/TO2/TO2HUDMgr.cpp
+++ b/Game/ClientShellDLL/TO2/TO2HUDMgr.cpp
@@ -68,6 +68,9 @@ CTO2HUDMgr::~CTO2HUDMgr()
 
 LTBOOL CTO2HUDMgr::Init()
 {
+	// Jake: Take damage should be first, it's a full-screen effect!
+	m_itemArray.push_back(&m_TakeDamage);
+
 	//crosshair should be first so that it is rendered first (potential overlap)
 	m_itemArray.push_back(&m_Crosshair);
 

--- a/Game/ClientShellDLL/TO2/TO2HUDMgr.cpp
+++ b/Game/ClientShellDLL/TO2/TO2HUDMgr.cpp
@@ -23,6 +23,7 @@ CHUDCompass*		g_pCompass = LTNULL;
 CHUDObjectives*		g_pObjectives = LTNULL;
 CHUDRadio*			g_pRadio = LTNULL;
 
+
 inline void CHUDItem::SetRenderState()
 {
 	g_pDrawPrim->SetTransformType(DRAWPRIM_TRANSFORM_SCREEN);
@@ -93,6 +94,7 @@ LTBOOL CTO2HUDMgr::Init()
 	g_pCompass = &m_Compass;
 	g_pObjectives = &m_Objectives;
 	g_pRadio = &m_Radio;
+	g_pTakeDamage = &m_TakeDamage;
 
 	m_itemArray.push_back(&m_WpnChooser);
 	m_itemArray.push_back(&m_AmmoChooser);

--- a/Game/ClientShellDLL/TO2/TO2HUDMgr.h
+++ b/Game/ClientShellDLL/TO2/TO2HUDMgr.h
@@ -62,7 +62,6 @@ protected:
 	CHUDRespawn			m_Respawn;
 	CHUDDoomsday		m_Doomsday;
 	CHUDFramerate		m_Framerate;
-	CHUDTakeDamage		m_TakeDamage;
 
 };
 
@@ -71,6 +70,5 @@ extern CHUDCrosshair*		g_pCrosshair;
 extern CHUDCompass*			g_pCompass;
 extern CHUDObjectives*		g_pObjectives;
 extern CHUDRadio*			g_pRadio;
-extern CHUDTakeDamage* g_pTakeDamage;
 
 #endif

--- a/Game/ClientShellDLL/TO2/TO2HUDMgr.h
+++ b/Game/ClientShellDLL/TO2/TO2HUDMgr.h
@@ -62,6 +62,7 @@ protected:
 	CHUDRespawn			m_Respawn;
 	CHUDDoomsday		m_Doomsday;
 	CHUDFramerate		m_Framerate;
+	CHUDTakeDamage		m_TakeDamage;
 
 };
 
@@ -70,5 +71,6 @@ extern CHUDCrosshair*		g_pCrosshair;
 extern CHUDCompass*			g_pCompass;
 extern CHUDObjectives*		g_pObjectives;
 extern CHUDRadio*			g_pRadio;
+extern CHUDTakeDamage* g_pTakeDamage;
 
 #endif


### PR DESCRIPTION
Fixes #46 

I have to remove the current functionality out of PlayerMgr, then finish off this HUDTakeDamage class to handle displaying when taking damage, and increase opacity depending on number of damage events we get.

Here's a preview:
![image](https://user-images.githubusercontent.com/3683240/83982463-a8b59c80-a8db-11ea-93a1-dd0e12094f30.png)
