### PR TITLE
Bugs/49 movement speed affected by fps

### DIFF
--- a/Game/ClientShellDLL/ClientShellShared/CMoveMgr.cpp
+++ b/Game/ClientShellDLL/ClientShellShared/CMoveMgr.cpp
@@ -2172,6 +2172,28 @@ void CMoveMgr::Update()
 	HOBJECT hObj = g_pLTClient->GetClientObject();
 	if (!m_hObject || !hObj) return;
 
+	//////////////////////////////////////////////////////////////////
+	static auto nStartTick = SDL_GetTicks();
+	static bool bForward = false;
+	if (m_dwControlFlags & BC_CFLG_FORWARD)
+	{
+		if (!bForward)
+		{
+			nStartTick = SDL_GetTicks();
+		}
+		bForward = true;
+
+	}
+	else
+	{
+		bForward = false;
+	}
+	if (bForward)
+	{
+		g_pLTClient->CPrint("Time: %d", SDL_GetTicks() - nStartTick);
+	}
+	//////////////////////////////////////////////////////////////////
+
 	m_eLastContainerCode = m_eCurContainerCode;
 	m_eCurContainerCode  = g_pPlayerMgr->GetCurContainerCode();
 

--- a/Game/ClientShellDLL/ClientShellShared/CMoveMgr.cpp
+++ b/Game/ClientShellDLL/ClientShellShared/CMoveMgr.cpp
@@ -1986,7 +1986,17 @@ void CMoveMgr::MoveLocalSolidObject()
     LTVector newPos, curPos;
 	bool bTouched = false;
 	bool bUseAltMovement = g_vtMovementFramerateFix.GetFloat() != 0.0f;
+
+	// If we're in spectator mode, don't apply our gravity.
+	// It's such an edgecase that we really don't need to handle it
+	if (g_pPlayerMgr->IsSpectatorMode())
+	{
+		bUseAltMovement = false;
+	}
+
 	LTFLOAT fDeltaTime = bUseAltMovement ? 0.016f : g_pGameClientShell->GetFrameTime();
+
+
 
 	// Check if we're using a vehicle physics model.
 	if( m_pVehicleMgr->IsVehiclePhysics( ))
@@ -2075,7 +2085,7 @@ void CMoveMgr::MoveLocalSolidObject()
 	// Handle our alternate jumping/falling
 	if (m_bYVelocitySet)
 	{
-		m_vYVelocity += m_fGravity * g_pGameClientShell->GetFrameTime();
+		m_vYVelocity += vNewGlobalForce.y * g_pGameClientShell->GetFrameTime();
 
 		// Value is tweaked to reach the "fall cam" threshold
 		info.m_Offset.y = m_vYVelocity.y * g_pGameClientShell->GetFrameTime() * 1.118f;

--- a/Game/ClientShellDLL/ClientShellShared/CMoveMgr.h
+++ b/Game/ClientShellDLL/ClientShellShared/CMoveMgr.h
@@ -271,6 +271,9 @@ class CMoveMgr
 	
 	LTVector		m_vCrouchDims;
 	LTVector		m_vStandDims;
+
+	LTVector		m_vYVelocity;
+	LTBOOL			m_bYVelocitySet;
 };
 
 


### PR DESCRIPTION
Okay cooool. This resolves #49 which is my way too long quest to fix movement speed.

I found that to get a consistent movement speed I need to simulate movement on a 60fps delta time, and then manually adjust it with the real delta time. 

That unfortunately broke jumping/falling. So I simulate gravity pretty much on par with how it originally works. (I'm glad it's so simple!) However like the original, jumping height is slightly framerate dependent. Not enough to make a difference though. 
