### PR TITLE
Don't run our sliding bar code on 4:3 resolutions.

### DIFF
--- a/Game/ClientShellDLL/ClientShellShared/InterfaceMgr.cpp
+++ b/Game/ClientShellDLL/ClientShellShared/InterfaceMgr.cpp
@@ -5136,7 +5136,12 @@ void CInterfaceMgr::UpdateLetterBox()
 //
 void CInterfaceMgr::UpdateSlidingBars()
 {
-	
+	// Only do black bars on resolutions greater than 4:3 otherwise it crashes!
+	if (g_pInterfaceResMgr->Get4x3Offset() <= 0)
+	{
+		return;
+	}
+
 #if 0
 	// This is the tan-ish colour that the CateBackground uses on the foreground
 	HLTCOLOR kBarColour = SETRGB(255, 215, 93);


### PR DESCRIPTION
This resolves the crash described in #59 