### PR TITLE
Allow GameInputMgr::MouseUp to run no matter what mode the game is at.

### DIFF
--- a/Game/ClientShellDLL/ClientShellShared/GameInputMgr.cpp
+++ b/Game/ClientShellDLL/ClientShellShared/GameInputMgr.cpp
@@ -79,10 +79,9 @@ void GameInputMgr::OnMouseDown(GameInputButton button)
 
 void GameInputMgr::OnMouseUp(GameInputButton button)
 {
-	if (!SDL_GetRelativeMouseMode())
-	{
-		return;
-	}
+	// Jake: There use to be a GetRelativeMouseMode check here,
+	// but that led to uncompleted inputs being left "on".
+	// So let's just finish up anything. 
 
 	if (button == GIB_LEFT_MOUSE)
 	{


### PR DESCRIPTION
Resolves #65 

I just removed the "Is in game" check on OnMouseUp. It turns out we want to release the mouse too! Whoops.