### PR TITLE
Bugs/89 weapon model and scope may be stretched or squished

### DIFF
--- a/Assets/Mod/Attributes/Layout.txt
+++ b/Assets/Mod/Attributes/Layout.txt
@@ -1831,9 +1831,9 @@ Scale9		= 0.05
 Sprite10		= "Interface\hud\Spr\warning.spr"
 Scale10		= 0.05
 Sprite11		= "Interface\hud\Spr\ssdead.spr"
-Scale11		= 0.18
+Scale11		= 0.23
 Sprite12		= "Interface\hud\Spr\rogue.spr"
-Scale12		= 0.18
+Scale12		= 0.23
 Sprite13		= "Interface\hud\Spr\SSMaskX.spr"
 Scale13		= 0.23
 

--- a/Game/ClientShellDLL/ClientShellShared/InterfaceMgr.cpp
+++ b/Game/ClientShellDLL/ClientShellShared/InterfaceMgr.cpp
@@ -4351,6 +4351,9 @@ void CInterfaceMgr::ScreenDimsChanged()
 
 	InterfaceFieldOfViewChanged();
 
+	// Correctly set the aspect ratio of our view models.
+	WriteConsoleFloat("pvmodelaspect", (float)dwWidth / (float)dwHeight);
+
 	// This may need to be changed to support in-game cinematics...
 	ResetMenuRestoreCamera(0, 0, dwWidth, dwHeight);
     g_pLTClient->SetCameraRect (m_hInterfaceCamera, LTTRUE, 0, 0, dwWidth, dwHeight);

--- a/Game/ClientShellDLL/ClientShellShared/InterfaceMgr.cpp
+++ b/Game/ClientShellDLL/ClientShellShared/InterfaceMgr.cpp
@@ -4686,12 +4686,8 @@ void CInterfaceMgr::UpdateOverlays()
 	LTVector vDefault(0.024f, 0.02f, 1.0f);
 	g_vOverlaySpriteScale = vDefault;
 
-	float fMax = 600.0f / 800.0f;
-	float fCurrent = g_pInterfaceResMgr->GetInvAspectRatio();
-
-	float fScale = (fCurrent) / (fMax);
-
-	g_vOverlaySpriteScale.x *= fScale;
+	// Just make the overlay square
+	g_vOverlaySpriteScale.x = g_vOverlaySpriteScale.y;
 
 	//
 	// End fun scaling stuff

--- a/Game/ClientShellDLL/ClientShellShared/InterfaceMgr.cpp
+++ b/Game/ClientShellDLL/ClientShellShared/InterfaceMgr.cpp
@@ -512,6 +512,9 @@ LTBOOL CInterfaceMgr::Init()
     g_pLTClient->SetCameraRect(m_hInterfaceCamera, LTFALSE, 0, 0, dwWidth, dwHeight);
     g_pLTClient->SetCameraFOV(m_hInterfaceCamera, DEG2RAD(g_vtInterfaceFOVX.GetFloat()), DEG2RAD(g_vtInterfaceFOVY.GetFloat()));
 
+	// Correctly set the aspect ratio of our view models.
+	WriteConsoleFloat("pvmodelaspect", (float)dwWidth / (float)dwHeight);
+
 	// read in the settings
     m_Settings.Init (g_pLTClient, g_pGameClientShell);
 

--- a/Game/ClientShellDLL/TO2/HUDCrosshair.cpp
+++ b/Game/ClientShellDLL/TO2/HUDCrosshair.cpp
@@ -362,11 +362,10 @@ void CHUDCrosshair::RenderScope()
 	float cx = 320.0f * g_pInterfaceResMgr->GetYRatio();
 	float cy = 240.0f * g_pInterfaceResMgr->GetYRatio();
 
-	//
-
-	float hR = g_vtScopeLRRadius.GetFloat() * cx * 2.0f;
+	// Values are adjusted using what I like to call, trial and error. Very scientific.
+	float hR = g_vtScopeLRRadius.GetFloat() * (cx * 0.75f) * 2.0f;
 	float hGap = g_vtScopeLRGap.GetFloat() * g_pInterfaceResMgr->GetYRatio();
-	float vR = g_vtScopeUDRadius.GetFloat() * cx * 2.0f;
+	float vR = g_vtScopeUDRadius.GetFloat() * (cy * 1.10f) * 2.0f;
 	float vGap = g_vtScopeUDGap.GetFloat() * g_pInterfaceResMgr->GetYRatio();
 
 	cx += g_pInterfaceResMgr->Get4x3Offset();
@@ -443,7 +442,6 @@ void CHUDCrosshair::RenderCamera()
 
 void CHUDCrosshair::RenderBlackBars(eOverlayMask eMask)
 {
-	return;//
 	int screenWidth = g_pInterfaceResMgr->GetScreenWidth();
 	int height = g_pInterfaceResMgr->GetScreenHeight();
 

--- a/Game/ClientShellDLL/TO2/HUDCrosshair.cpp
+++ b/Game/ClientShellDLL/TO2/HUDCrosshair.cpp
@@ -443,20 +443,13 @@ void CHUDCrosshair::RenderCamera()
 
 void CHUDCrosshair::RenderBlackBars(eOverlayMask eMask)
 {
-	// Black bars if we need it!
-	if (!g_pInterfaceResMgr->Get4x3Offset()) {
-		return;
-	}
-
-	// This will return stuff like 0.75f, we want an additive scale..
-	auto fInvScale = g_pLayoutMgr->GetMaskScale(eMask);
-	// Flip that inverse scale!
-	auto fScale = (1.0f - fInvScale) + 1.0f;
-
-	int width = g_pInterfaceResMgr->Get4x3Offset() * fScale;
+	return;//
+	int screenWidth = g_pInterfaceResMgr->GetScreenWidth();
 	int height = g_pInterfaceResMgr->GetScreenHeight();
 
-	int screenWidth = g_pInterfaceResMgr->GetScreenWidth();
+	// Basically from Get4x3Offset, but since overlays are now square..we don't need the 4x3-ness.
+	int ratio = (int)(0.5f * (screenWidth - (height)));
+	int width = ratio;
 
 	g_pDrawPrim->SetRGBA(&m_Poly[2], argbBlack);
 

--- a/Game/ClientShellDLL/TO2/ScreenDisplay.cpp
+++ b/Game/ClientShellDLL/TO2/ScreenDisplay.cpp
@@ -373,6 +373,16 @@ void CScreenDisplay::GetRendererData()
 			}
 			*/
 
+			// There's something about this resolution that just crashes. 
+			// It's so weird, for now let's put it in resolution jail!
+			if (pCurrentMode->m_Width == 1176
+				&& pCurrentMode->m_Height == 664)
+			{
+				// Go to the next render mode
+				pCurrentMode = pCurrentMode->m_pNext;
+				continue;
+			}
+
 			//disallow any that aren't hardware TnL
 			if(bHWTnL && !pCurrentMode->m_bHWTnL)
 			{


### PR DESCRIPTION
Fixes #89 

This also means scopes and other overlays properly work in any resolution (Aside from the little ticks on sniper scopes..I'll have to look into that..)
![image](https://user-images.githubusercontent.com/3683240/102750281-65bc9300-431a-11eb-85c1-9a9f3babdb29.png)

I haven't tested this in all cases, I'm sure it fails during cinematics..hmm